### PR TITLE
Upgrade AWS provider to 6.x

### DIFF
--- a/versions.tf
+++ b/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 5.0"
+      version = "~> 6.0"
     }
   }
 }


### PR DESCRIPTION
My employer is upgrading our internal Terraform modules to use the latest AWS provider, so also have to update dependencies.